### PR TITLE
Dependencies: Migrate from `crate[sqlalchemy]` to `sqlalchemy-cratedb`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,6 @@ dependencies = [
   "click<9",
   "colorama<0.5",
   "colorlog<7",
-  "crate[sqlalchemy]",
   "fastapi<0.112",
   "halo<0.1",
   "icecream<3",
@@ -97,6 +96,7 @@ dependencies = [
   "pydantic<3",
   "python-dotenv[cli]<2",
   "python-multipart==0.0.9",
+  "sqlalchemy-cratedb",
   "uvicorn<0.31",
   "watchdog<5",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ dependencies = [
   "icecream<3",
   "Jinja2<4",
   "MarkupSafe<3",
-  "pueblo[fileio]@ git+https://github.com/pyveci/pueblo@main",
+  "pueblo[fileio]",
   "pydantic<3",
   "python-dotenv[cli]<2",
   "python-multipart==0.0.9",


### PR DESCRIPTION
## About
The [CrateDB SQLAlchemy dialect](https://github.com/crate-workbench/sqlalchemy-cratedb) needs more love, so it was separated from the [DBAPI HTTP driver](https://github.com/crate/crate-python). This patch intends to accompany the migration.

## Details
The new canonical package for the SQLAlchemy CrateDB dialect on PyPI is:

> https://pypi.org/project/sqlalchemy-cratedb/
