### PR TITLE
Dependencies: Migrate from `crate[sqlalchemy]` to `sqlalchemy-cratedb`, part 2

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+# https://docs.codecov.io/docs/common-recipe-list
+# https://docs.codecov.io/docs/commit-status#patch-status
+
+coverage:
+  status:
+
+    project:
+      default:
+        target: auto    # the required coverage value
+        threshold: 3%   # the leniency in hitting the target
+
+    patch:
+      default:
+        target: auto    # the required coverage value
+        threshold: 3%   # the leniency in hitting the target

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ dependencies = [
   "pydantic<3",
   "python-dotenv[cli]<2",
   "python-multipart==0.0.9",
-  "sqlalchemy-cratedb",
+  "sqlalchemy-cratedb==0.37.0",
   "uvicorn<0.31",
   "watchdog<5",
 ]
@@ -114,7 +114,7 @@ release = [
   "twine<6",
 ]
 test = [
-  "cratedb-toolkit==0.0.12",
+  "cratedb-toolkit==0.0.14",
   "httpx<0.28",
   "psycopg2-binary<3",
   "pytest<9",

--- a/supertask/store/cratedb.py
+++ b/supertask/store/cratedb.py
@@ -65,10 +65,9 @@ class CrateDBSQLAlchemyJobStore(SQLAlchemyJobStore):
         """
         A few patches to make the CrateDB SQLAlchemy dialect work.
 
-        TODO: Upstream to crate-python.
         """
-        from crate.client.sqlalchemy import CrateDialect
-        from crate.client.sqlalchemy.compiler import CrateDDLCompiler, CrateTypeCompiler
+        from sqlalchemy_cratedb import dialect
+        from sqlalchemy_cratedb.compiler import CrateDDLCompiler, CrateTypeCompiler
 
         def visit_BLOB(self, type_, **kw):
             return "STRING"
@@ -102,7 +101,7 @@ class CrateDBSQLAlchemyJobStore(SQLAlchemyJobStore):
 
         CrateDDLCompiler.visit_create_index = visit_create_index
 
-        CrateDialect.colspecs.update(
+        dialect.colspecs.update(
             {
                 sa.sql.sqltypes.LargeBinary: LargeBinary,
             }

--- a/supertask/util.py
+++ b/supertask/util.py
@@ -18,4 +18,5 @@ def setup_logging(level=logging.INFO, debug: bool = False, width: int = 30):
         logging.getLogger("sqlalchemy").setLevel(level)
 
     logging.getLogger("crate.client").setLevel(level)
+    logging.getLogger("sqlalchemy_cratedb").setLevel(level)
     logging.getLogger("urllib3.connectionpool").setLevel(level)


### PR DESCRIPTION
Missed updating module references on the previous iteration GH-84.