### PR TITLE
Dependencies: Add package `pytz`, it was suddenly missing?

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ dependencies = [
   "pydantic<3",
   "python-dotenv[cli]<2",
   "python-multipart==0.0.16",
+  "pytz",
   "sqlalchemy-cratedb==0.40.0",
   "uvicorn<0.33",
   "watchdog<6",


### PR DESCRIPTION
What the title says.