### PR TITLE
Dependabot: Configure "widen" versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    versioning-strategy: "widen"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## About
It looks like Dependabot's default [versioning strategy](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#versioning-strategy--) might recently have changed to "increase". Let's explicitly select "widen" again.

## References

- GH-219
- GH-220
- GH-223
