### PR TITLE
Dependabot: Configure "widen" versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    versioning-strategy: "widen"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
It looks like the default versioning strategy might recently have changed to "increase".

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#versioning-strategy--