### PR TITLE
Dependencies: Update to sqlalchemy-cratedb 0.43.0, remove monkeypatches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: [
-          "3.9",
+          "3.10",
           "3.14",
         ]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Dependencies: Updated to sqlalchemy-cratedb 0.43.0
+- Runtime: Removed support for Python 3.9
 
 ## 2026/05/14 v0.0.0
 - Make it work

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Dependencies: Updated to sqlalchemy-cratedb 0.43.0
 
 ## 2026/05/14 v0.0.0
 - Make it work

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ authors = [
   { name = "Walter Behmann", email = "walter@crate.io" },
   { name = "Andreas Motl", email = "andreas.motl@crate.io" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Environment :: Console",
@@ -47,7 +47,6 @@ classifiers = [
   "Operating System :: Unix",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ dependencies = [
   "python-dotenv[cli]<2",
   "python-multipart<0.0.21",
   "pytz",
-  "sqlalchemy-cratedb==0.41.0",
+  "sqlalchemy-cratedb==0.43.0",
   "tomli<3",
   "uvicorn<0.41",
   "watchdog<7",

--- a/supertask/store/cratedb.py
+++ b/supertask/store/cratedb.py
@@ -49,17 +49,9 @@ class CrateDBSQLAlchemyJobStore(SQLAlchemyJobStore):
     def __init__(self, *args, **kwargs):
         self.patchme()
         super().__init__(*args, **kwargs)
+        from sqlalchemy_cratedb.support import refresh_after_dml
 
-        def receive_after_execute(
-            conn: sa.engine.Connection, clauseelement, multiparams, params, execution_options, result
-        ):
-            """
-            Run a `REFRESH TABLE ...` command after each DML operation (INSERT, UPDATE, DELETE).
-            """
-            if isinstance(clauseelement, (sa.sql.Insert, sa.sql.Update, sa.sql.Delete)):
-                conn.execute(sa.text(f"REFRESH TABLE {clauseelement.table}"))
-
-        sa.event.listen(self.engine, "after_execute", receive_after_execute)
+        refresh_after_dml(self.engine)
 
     def patchme(self):
         """
@@ -67,39 +59,12 @@ class CrateDBSQLAlchemyJobStore(SQLAlchemyJobStore):
 
         """
         from sqlalchemy_cratedb import dialect
-        from sqlalchemy_cratedb.compiler import CrateDDLCompiler, CrateTypeCompiler
+        from sqlalchemy_cratedb.compiler import CrateTypeCompiler
 
         def visit_BLOB(self, type_, **kw):
             return "STRING"
 
-        def visit_FLOAT(self, type_, **kw):
-            """
-            From `sqlalchemy.sql.sqltypes.Float`.
-
-            When a :paramref:`.Float.precision` is not provided in a
-            :class:`_types.Float` type some backend may compile this type as
-            an 8 bytes / 64 bit float datatype. To use a 4 bytes / 32 bit float
-            datatype a precision <= 24 can usually be provided or the
-            :class:`_types.REAL` type can be used.
-            This is known to be the case in the PostgreSQL and MSSQL dialects
-            that render the type as ``FLOAT`` that's in both an alias of
-            ``DOUBLE PRECISION``. Other third party dialects may have similar
-            behavior.
-            """
-            if not type_.precision:
-                return "FLOAT"
-            elif type_.precision <= 24:
-                return "FLOAT"
-            else:
-                return "DOUBLE"
-
         CrateTypeCompiler.visit_BLOB = visit_BLOB
-        CrateTypeCompiler.visit_FLOAT = visit_FLOAT
-
-        def visit_create_index(self, create, **kw):
-            return "SELECT 1;"
-
-        CrateDDLCompiler.visit_create_index = visit_create_index
 
         dialect.colspecs.update(
             {


### PR DESCRIPTION
## About
Remove custom monkeypatches after release of the SQLAlchemy dialect.

## References
- https://github.com/crate/sqlalchemy-cratedb/issues/273
